### PR TITLE
set smooth: duplicate line

### DIFF
--- a/.nanorc
+++ b/.nanorc
@@ -8,15 +8,15 @@
 #
 
 unset autoindent
-set nowrap
+#set nowrap
 set matchbrackets "(<[{)>]}"
 ## set brackets "\"')]}"
 ## unset mouse
 set tabsize 8
 set softwrap
-set suspend
+set suspendable
 set const
-set smooth
+#set smooth
 set rebindkeypad
 set boldtext
 set multibuffer

--- a/.nanorc
+++ b/.nanorc
@@ -27,7 +27,6 @@ set quickblank
 set wordbounds
 ## set undo  # (still experimental/buggy on nano 2.2.x)
 set nonewlines
-set smooth
 
 #| File          : ~/.nanorc
 #| Last modified : 2012-02-28


### PR DESCRIPTION
There is a duplicate line.

Also, on GNU nano 5.6.1 (tested with arch) there is a line that trigger error in ".nanorc" --> "set const"

I am happy to use your repo, thanks for this!